### PR TITLE
Checkout main by default if branch is missing in LinCity-NG repo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,12 @@ echo "Building Lincity-ng"
 cd lincity-ng
 
 if [ $# == 1 ]; then
-    git checkout "$1"
+    if git branch | grep "$1"; then
+        git checkout "$1"
+    else
+        echo "Warning: branch $1 not found. Using main by default."
+        git checkout main
+    fi
 fi
 
 if [ ! -f configure ]; then


### PR DESCRIPTION
This allows for building PRs successfully in the LinCity-NG webassembly repo if the corresponding
branch in the LinCity-NG repo is missing.